### PR TITLE
Fixe syntax error in LSF job template

### DIFF
--- a/sparkhpc/templates/sparkjob.lsf.template
+++ b/sparkhpc/templates/sparkjob.lsf.template
@@ -18,5 +18,5 @@ from sparkhpc import sparkjob
 sparkjob.start_cluster('{memory_per_executor}M', 
                        cores_per_executor={cores_per_executor}, 
                        spark_home='{spark_home}',
-                       master_log_dir='{master_log_dir}'
+                       master_log_dir='{master_log_dir}',
                        master_log_filename='{master_log_filename}')


### PR DESCRIPTION
Missing comma after `master_log_dir` argument.