### PR TITLE
fixed Python 3 issue with Slurm jobs

### DIFF
--- a/sparkhpc/sparkjob.py
+++ b/sparkhpc/sparkjob.py
@@ -350,7 +350,7 @@ class SparkJob(object):
         job = template_str.format(walltime=self.walltime, 
                                   ncores=self.ncores, 
                                   cores_per_executor=self.cores_per_executor,
-                                  number_of_executors=self.ncores/self.cores_per_executor,
+                                  number_of_executors=int(self.ncores/self.cores_per_executor),
                                   memory_per_core=self.memory_per_core, 
                                   memory_per_executor=self.memory_per_executor,
                                   jobname=self.jobname, 
@@ -587,7 +587,7 @@ def start_cluster(memory,
     if scheduler=='slurm':
         # the master will start on the first host but gethostbyname doesn't always work, 
         # e.g. if using salloc 
-        nodelist = subprocess.check_output(shlex.split('srun hostname -f')).split('\n')[:-1]
+        nodelist = subprocess.check_output(shlex.split('srun hostname -f')).decode().split('\n')[:-1]
         nodelist.sort()
         master_host=nodelist[0].split('.')[0]
     else:

--- a/sparkhpc/templates/sparkjob.slurm.template
+++ b/sparkhpc/templates/sparkjob.slurm.template
@@ -2,10 +2,10 @@
 #SBATCH -J {jobname}
 #SBATCH -t {walltime} # runtime to request !!! in minutes !!!
 #SBATCH -o {jobname}-%J.log # output extra o means overwrite
-#SBATCH -n {number_of_executors} # requesting n tasks
-#SBATCH -c {cores_per_executor}
-#SBATCH --mem-per-cpu={memory_per_core} 
-#SBATCH -N {number_of_executors}
+#SBATCH -n {number_of_executors:d} # requesting n tasks
+#SBATCH -c {cores_per_executor:d}
+#SBATCH --mem-per-cpu={memory_per_core:d} 
+#SBATCH -N {number_of_executors:d}
 #SBATCH --ntasks-per-core=1
 
 # setup the spark paths


### PR DESCRIPTION
Tried to do this in the most pythonic way I could find.  The issue was that the Slurm job script was getting floats for the amount of memory/number of cpus in the job script which Slurm was rejecting.  I set the template to write integers only for those fields.
